### PR TITLE
Add async httpx scraping with caching and throttling

### DIFF
--- a/projects/World of Warcraft/python-tests/scraper_wiki.py
+++ b/projects/World of Warcraft/python-tests/scraper_wiki.py
@@ -1,38 +1,151 @@
-import requests
-from bs4 import BeautifulSoup
-import hashlib
-import time
+import asyncio
+import atexit
+import os
 import re
+import time
+import hashlib
+
+import httpx
+from bs4 import BeautifulSoup
+from tenacity import AsyncRetrying, RetryError, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+try:
+    from requests_cache import AsyncCachedSession
+except Exception:  # pragma: no cover - optional dependency
+    AsyncCachedSession = None
 
 
-def pobierz_soup(url: str, parser: str = "html.parser") -> BeautifulSoup | None:
-    headers = {
-        "User-Agent": "WoW_PolishTranslationProject -> (reachable on your Discord: Loe'Aner)"
+USER_AGENT = "WoW_PolishTranslationProject -> (reachable on your Discord: Loe'Aner)"
+DEFAULT_TIMEOUT = 30
+
+ENABLE_CACHE = os.getenv("SCRAPER_CACHE_ENABLED", "0").lower() in {"1", "true", "yes"}
+CACHE_NAME = os.getenv("SCRAPER_CACHE_NAME", "wow_scraper_cache")
+CACHE_EXPIRE = int(os.getenv("SCRAPER_CACHE_EXPIRE", "86400"))
+
+WIKI_SEMAPHORE = asyncio.Semaphore(int(os.getenv("WIKI_MAX_CONCURRENCY", "3")))
+WOWHEAD_SEMAPHORE = asyncio.Semaphore(int(os.getenv("WOWHEAD_MAX_CONCURRENCY", "3")))
+
+WIKI_DELAY = float(os.getenv("WIKI_DELAY_SECONDS", "1.0"))
+WOWHEAD_DELAY = float(os.getenv("WOWHEAD_DELAY_SECONDS", "1.5"))
+
+
+class HostThrottle:
+    def __init__(self, min_delay: float):
+        self.min_delay = max(0.0, min_delay)
+        self._lock = asyncio.Lock()
+        self._last_call = 0.0
+
+    async def wait(self) -> None:
+        async with self._lock:
+            elapsed = time.monotonic() - self._last_call
+            remaining = self.min_delay - elapsed
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+            self._last_call = time.monotonic()
+
+
+THROTTLES = {
+    "wiki": HostThrottle(WIKI_DELAY),
+    "wowhead": HostThrottle(WOWHEAD_DELAY),
+}
+
+_CLIENT: httpx.AsyncClient | None = None
+
+
+def _build_client() -> httpx.AsyncClient:
+    common_kwargs = {
+        "headers": {"User-Agent": USER_AGENT},
+        "timeout": DEFAULT_TIMEOUT,
+        "follow_redirects": True,
     }
 
-    proby = 6
-    opoznienie = 2
+    if ENABLE_CACHE and AsyncCachedSession is not None:
+        return AsyncCachedSession(
+            cache_name=CACHE_NAME,
+            backend="sqlite",
+            expire_after=CACHE_EXPIRE,
+            allowable_methods=["GET"],
+            **common_kwargs,
+        )
 
-    for i in range(1, proby + 1):
-        try:
-            odpowiedz = requests.get(url, headers=headers, timeout=30)
+    return httpx.AsyncClient(**common_kwargs)
 
-            if odpowiedz.status_code in (429, 502, 503):
-                wait_s = opoznienie * (2 ** (i - 1))
-                print(f"{odpowiedz.status_code} dla {url} – czekam {wait_s}s (próba {i}/{proby})")
-                time.sleep(wait_s)
-                continue
 
-            odpowiedz.raise_for_status()
-            return BeautifulSoup(odpowiedz.text, parser)
+def _get_client() -> httpx.AsyncClient:
+    global _CLIENT
+    if _CLIENT is None:
+        _CLIENT = _build_client()
+    return _CLIENT
 
-        except requests.exceptions.RequestException as e:
-            wait_s = opoznienie * (2 ** (i - 1))
-            print(f"Błąd requestu dla {url}: {e} – retry za {wait_s}s (próba {i}/{proby})")
-            time.sleep(wait_s)
 
-    print(f"SKIP: nie udało się pobrać {url} po {proby} próbach")
-    return None
+def _close_client() -> None:
+    global _CLIENT
+    if _CLIENT is None:
+        return
+
+    client = _CLIENT
+    _CLIENT = None
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = None
+
+    async def _close_async():
+        await client.aclose()
+
+    if loop and loop.is_running():
+        loop.create_task(_close_async())
+    else:
+        asyncio.run(_close_async())
+
+
+atexit.register(_close_client)
+
+
+async def _fetch_html(url: str, host: str) -> str:
+    client = _get_client()
+    semaphore = WIKI_SEMAPHORE if host == "wiki" else WOWHEAD_SEMAPHORE
+    throttle = THROTTLES[host]
+
+    async def _do_request() -> httpx.Response:
+        async with semaphore:
+            await throttle.wait()
+            response = await client.get(url)
+        if response.status_code in (429, 502, 503):
+            raise httpx.HTTPStatusError(
+                f"{response.status_code} status for {url}",
+                request=response.request,
+                response=response,
+            )
+        response.raise_for_status()
+        return response
+
+    try:
+        async for attempt in AsyncRetrying(
+            stop=stop_after_attempt(6),
+            wait=wait_exponential(multiplier=1, min=2, max=60),
+            retry=retry_if_exception_type(httpx.HTTPError),
+            reraise=True,
+        ):
+            with attempt:
+                return (await _do_request()).text
+    except RetryError as exc:
+        print(f"SKIP: nie udało się pobrać {url} po 6 próbach: {exc}")
+        raise
+
+
+async def pobierz_soup_async(url: str, parser: str = "html.parser", host: str | None = None) -> BeautifulSoup | None:
+    target_host = host or ("wowhead" if "wowhead" in url else "wiki")
+    try:
+        html = await _fetch_html(url, target_host)
+        return BeautifulSoup(html, parser)
+    except (httpx.HTTPError, RetryError) as e:
+        print(f"Błąd pobierania {url}: {e}")
+        return None
+
+
+def pobierz_soup(url: str, parser: str = "html.parser", host: str | None = None) -> BeautifulSoup | None:
+    return asyncio.run(pobierz_soup_async(url, parser=parser, host=host))
 
 
 

--- a/projects/World of Warcraft/python-tests/scraper_wowhead.py
+++ b/projects/World of Warcraft/python-tests/scraper_wowhead.py
@@ -1,10 +1,12 @@
+import asyncio
 import os
+import random
 import re
 import time
-import random
+
 import pandas as pd
 from openpyxl import Workbook, load_workbook
-from scraper_wiki import pobierz_soup
+from scraper_wiki import pobierz_soup_async
 
 
 def wyciagnij_patch(soup):
@@ -29,7 +31,11 @@ def normalize_cell(v):
         return None
     return v
 
-def buduj_mapping_01():
+async def _pobierz_soup_wowhead(url: str):
+    return await pobierz_soup_async(url, parser="lxml", host="wowhead")
+
+
+async def buduj_mapping_01_async():
     """
     Tworzy nowego excela, który jest rozbudowany o nazwę linii fabularnej oraz w którym patchu dodano misję.
     Funkcja bazuje na excelu "surowym", który znajduje się w folderze "surowe" -> plik "wowhead_id_kraina_dodatek".
@@ -95,7 +101,7 @@ def buduj_mapping_01():
         link = row_dict[url_col]
 
         print(f"[{idx}/{len(df_new)}] Scrapuję: {link}")
-        soup = pobierz_soup(link, parser="lxml")
+        soup = await _pobierz_soup_wowhead(link)
 
         if soup is None:
             bledy += 1
@@ -130,7 +136,7 @@ def buduj_mapping_01():
             print(f"Zapisano paczkę {len(bufor)} wierszy od wiersza {start_row}")
             bufor = []
 
-        time.sleep(random.uniform(1.3, 1.9))
+        await asyncio.sleep(random.uniform(1.3, 1.9))
 
     if bufor:
         start_row = ws.max_row + 1
@@ -141,3 +147,7 @@ def buduj_mapping_01():
         print(f"Zapisano ostatnią paczkę {len(bufor)} wierszy od wiersza {start_row}")
 
     print(f"Koniec. Dopisano: {dopisane}, błędy pobierania: {bledy}")
+
+
+def buduj_mapping_01():
+    asyncio.run(buduj_mapping_01_async())


### PR DESCRIPTION
## Summary
- replace synchronous requests usage with a shared async httpx client that supports optional SQLite caching, retry backoff, and host-specific throttling
- update wiki and wowhead scrapers to use async fetch helpers with semaphores and consistent user agent headers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b164ff96083208ec89e5b3f66dbff)